### PR TITLE
Fix resource cross-contamination under concurrent JUnit 5 execution

### DIFF
--- a/lib/src/main/kotlin/com/asarkar/grpc/test/ExtensionContextUtils.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/ExtensionContextUtils.kt
@@ -12,22 +12,43 @@ private object ExtensionContextUtils {
     internal val NAMESPACE: ExtensionContext.Namespace =
         ExtensionContext.Namespace
             .create(*GrpcCleanupExtension::class.java.name.split(".").toTypedArray())
+
+    // Per-test (once=false): only ever written to method-level contexts.
+    // Keeping it out of class-level contexts ensures the Store hierarchy walk never returns
+    // a shared list to a concurrent sibling test.
     internal const val RESOURCES = "resources"
+
+    // Per-class (once=true): only ever written to class-level contexts, cleaned in afterAll.
+    internal const val RESOURCES_ONCE = "resources-once"
     internal const val RESOURCES_FIELD = "resources-field"
 }
 
 @Suppress("UNCHECKED_CAST")
-internal var ExtensionContext.resources: MutableMap<Boolean, MutableList<Resources>>
+internal var ExtensionContext.resources: MutableList<Resources>
     get() =
         getStore(ExtensionContextUtils.NAMESPACE)
             .getOrDefault(
                 ExtensionContextUtils.RESOURCES,
-                MutableMap::class.java,
-                mutableMapOf<Boolean, MutableList<Resources>>(),
-            ) as MutableMap<Boolean, MutableList<Resources>>
+                MutableList::class.java,
+                mutableListOf<Resources>(),
+            ) as MutableList<Resources>
     set(value) {
         getStore(ExtensionContextUtils.NAMESPACE)
             .put(ExtensionContextUtils.RESOURCES, value)
+    }
+
+@Suppress("UNCHECKED_CAST")
+internal var ExtensionContext.resourcesOnce: MutableList<Resources>
+    get() =
+        getStore(ExtensionContextUtils.NAMESPACE)
+            .getOrDefault(
+                ExtensionContextUtils.RESOURCES_ONCE,
+                MutableList::class.java,
+                mutableListOf<Resources>(),
+            ) as MutableList<Resources>
+    set(value) {
+        getStore(ExtensionContextUtils.NAMESPACE)
+            .put(ExtensionContextUtils.RESOURCES_ONCE, value)
     }
 
 internal var ExtensionContext.resourcesField: Field?

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
@@ -48,7 +48,7 @@ class GrpcCleanupExtension :
 
     override fun afterEach(ctx: ExtensionContext) {
         var successful = true
-        ctx.resources[false]?.forEach {
+        ctx.resources.forEach {
             ctx.cleanUp(it)
             successful = it.awaitRelease()
         }
@@ -87,10 +87,11 @@ class GrpcCleanupExtension :
                 )
 
         return Resources().also { resources ->
-            extensionCtx.resources =
-                extensionCtx.resources.also {
-                    it.getOrPut(once) { mutableListOf() }.add(resources)
-                }
+            if (once) {
+                extensionCtx.resourcesOnce = extensionCtx.resourcesOnce.also { it.add(resources) }
+            } else {
+                extensionCtx.resources = extensionCtx.resources.also { it.add(resources) }
+            }
         }
     }
 
@@ -116,7 +117,7 @@ class GrpcCleanupExtension :
             ctx.cleanUp(it)
             successful = it.awaitRelease()
         }
-        ctx.resources[true]?.forEach {
+        ctx.resourcesOnce.forEach {
             ctx.cleanUp(it)
             successful = it.awaitRelease()
         }

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
@@ -2,6 +2,7 @@ package com.asarkar.grpc.test
 
 import com.asarkar.grpc.test.ignore.ExampleTestCase
 import com.asarkar.grpc.test.ignore.ExampleTestCase10
+import com.asarkar.grpc.test.ignore.ExampleTestCase11
 import com.asarkar.grpc.test.ignore.ExampleTestCase2
 import com.asarkar.grpc.test.ignore.ExampleTestCase3
 import com.asarkar.grpc.test.ignore.ExampleTestCase4
@@ -379,6 +380,29 @@ class GrpcCleanupExtensionIntegrationTests {
 
         assertThat(mocks).allMatch { it is Set<*> }
         assertThat(mocks.flatMap { it as Set<*> }.toSet()).hasSize(3)
+    }
+
+    @Test
+    fun testConcurrentResourceIsolation() {
+        // Enables parallel execution only for this EngineTestKit run, not globally.
+        // With the bug, testA fails because testB's afterEach prematurely shuts down
+        // testA's channel via the shared MutableMap in the class-level Store entry.
+        EngineTestKit.engine(JUNIT_JUPITER)
+            .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+            .configurationParameter("junit.jupiter.execution.parallel.mode.default", "concurrent")
+            .configurationParameter("junit.jupiter.execution.parallel.config.strategy", "fixed")
+            .configurationParameter(
+                "junit.jupiter.execution.parallel.config.fixed.parallelism",
+                "2",
+            )
+            .selectors(selectClass(ExampleTestCase11::class.java))
+            .execute()
+            .testEvents()
+            .assertThatEvents()
+            .haveExactly(
+                2,
+                event(finishedSuccessfully()),
+            )
     }
 
     @Test

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase11.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase11.kt
@@ -1,0 +1,70 @@
+package com.asarkar.grpc.test.ignore
+
+import com.asarkar.grpc.test.GrpcCleanupExtension
+import com.asarkar.grpc.test.Resources
+import com.asarkar.grpc.test.TestUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduces the parallel-execution resource-isolation bug.
+ *
+ * The bug: [GrpcCleanupExtension]'s [ExtensionContext.Store] uses [getOrDefault], which walks
+ * the context hierarchy. When [beforeAll] stores its [Resources] under the class-level context,
+ * concurrent [resolveParameter] calls for [testA] and [testB] both find that same mutable map
+ * via the hierarchy walk and append their own resources to the shared `false`-keyed list.
+ *
+ * Consequence: [afterEach] for [testB] cleans the shared list — which now contains [testA]'s
+ * channel — while [testA] is still running. [testA] then observes `channelA.isShutdown == true`
+ * and fails.
+ *
+ * Run via [com.asarkar.grpc.test.GrpcCleanupExtensionIntegrationTests.testConcurrentResourceIsolation]
+ * with parallel execution enabled; never run directly by the Gradle test task (excluded via the
+ * `ignore` package filter in build.gradle.kts).
+ */
+@ExtendWith(GrpcCleanupExtension::class)
+@TestInstance(PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
+class ExampleTestCase11 {
+    companion object {
+        @JvmStatic
+        val barrier = CyclicBarrier(2)
+    }
+
+    @BeforeAll
+    fun beforeAll(resources: Resources) {
+        // Storing any resource here causes the class-level ExtensionContext.Store to hold the
+        // shared MutableMap<Boolean, MutableList<Resources>> under the "resources" key.
+        // Concurrent method-level resolveParameter calls then retrieve that same map object
+        // via getOrDefault's hierarchy walk, creating the shared-state race.
+        resources.register(TestUtils.randomChannel())
+    }
+
+    @Test
+    fun testA(resources: Resources) {
+        val ch = TestUtils.randomChannel()
+        resources.register(ch)
+        // Both tests must have registered before either exits, ensuring both are in the
+        // shared resource list before testB's afterEach fires.
+        barrier.await(5, TimeUnit.SECONDS)
+        // Give testB time to return and its afterEach to run. With the bug, afterEach for
+        // testB drains the shared list which includes testA's channel, shutting it down.
+        Thread.sleep(300)
+        assertThat(ch.isShutdown).isFalse()
+    }
+
+    @Test
+    fun testB(resources: Resources) {
+        resources.register(TestUtils.randomChannel())
+        barrier.await(5, TimeUnit.SECONDS)
+        // Return immediately so afterEach fires while testA is still sleeping.
+    }
+}


### PR DESCRIPTION
JUnit 5's ExtensionContext.Store.getOrDefault walks the context hierarchy: a value stored in a parent context is visible to all descendants.  The old code stored per-test and per-class Resources under the same "resources" key as a MutableMap<Boolean, List<Resources>>.

When a PER_CLASS test class has a @BeforeAll method with a Resources parameter, resolveParameter stores {true: [R_ba]} in the class-level context.  Concurrent @Test resolveParameter calls on method-level contexts then find that same MutableMap via the hierarchy walk and both append to the shared false-keyed list: {true: [R_ba], false: [R1, R2]}. afterEach for the first test to finish then drains the shared list and shuts down the still-running sibling's gRPC channel, causing "UNAVAILABLE: Channel shutdown invoked" mid-flight.

Fix: use separate Store keys for the two lifetimes.
- "resources"      (once=false): written only to method-level contexts.
  The hierarchy walk from a sibling's method context finds nothing in
  the class context (which carries only "resources-once"), so it gets
  an independent empty list.
- "resources-once" (once=true): written only to class-level contexts,
  cleaned in afterAll, never visible to per-test cleanup.

ExampleTestCase11 reproduces the race deterministically with a CyclicBarrier: testB finishes immediately after the barrier and its afterEach fires while testA is still sleeping; testA then asserts its channel has not been shut down.  The new testConcurrentResourceIsolation integration test runs ExampleTestCase11 with a fixed parallelism-2 pool via EngineTestKit and expects both tests to pass.