### PR TITLE
chore: Bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version-file: ".java-version"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,35 +1,29 @@
 name: Publish
 on:
   workflow_dispatch:
-    inputs:
-      ci:
-        description: "CI pipeline name"
-        required: false
-        default: "ci.yml"
 
 jobs:
   Publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v5
-
-      - name: Check CI status
-        id: check
+      - name: Abort if latest CI on main did not succeed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          output=$(curl -sSL -X GET -G -H "Accept: application/vnd.github.v3+json" -d "branch=${{ env.GITHUB_REF_NAME_SLUG }}" -d "event=push" https://api.github.com/repos/${{ github.repository }}/actions/workflows/${{ github.event.inputs.ci }}/runs | jq -r '.workflow_runs[0] | "\(.conclusion)"')
-          echo "status=$output" >> "$GITHUB_OUTPUT"
+          conclusion=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow=ci.yml \
+            --branch=main \
+            --limit=1 \
+            --json conclusion \
+            --jq '.[0].conclusion')
+          echo "Latest CI conclusion: $conclusion"
+          [ "$conclusion" = "success" ] || exit 1
 
-      - name: Abort if CI not successful
-        if: steps.check.outputs.status != 'success'
-        run: |
-          echo ${{ steps.check.outputs.status }}
-          exit 1
+      - uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version-file: ".java-version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 projectGroup=com.asarkar.grpc
-projectVersion=2.0.0
+projectVersion=2.0.1
 projectDescription=JUnit5 Extension that can automatically release gRPC resources at the end of the test
 licenseName=Apache-2.0
 licenseUrl=http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-junit5 = "5.12.2"
-grpc = "1.72.0"
-mockito = "5.17.0"
+junit6 = "6.0.3"
+grpc = "1.79.0"
+mockito = "5.23.0"
 # Refer to the following for Kotlin plugin version:
 # Kotlin JVM plugin compatibility chart: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 # Gradle Embedded Kotlin version compatibility chart: https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-kotlinPlugin = "2.0.20"
-dokkaPlugin = "2.0.0"
-ktlintPlugin = "12.2.0"
-mavenPublishPlugin = "0.31.0"
-spotbugs = "4.9.3"
-errorprone = "2.38.0"
-spotbugsPlugin = "6.1.9"
-spotlessPlugin = "7.0.3"
-errorpronePlugin = "4.2.0"
-palantirJavaFmt = "2.63.0"
+kotlinPlugin = "2.0.21"
+dokkaPlugin = "2.1.0"
+ktlintPlugin = "14.2.0"
+mavenPublishPlugin = "0.35.0"
+spotbugs = "4.9.8"
+errorprone = "2.42.0"
+spotbugsPlugin = "6.4.8"
+spotlessPlugin = "8.3.0"
+errorpronePlugin = "5.1.0"
+palantirJavaFmt = "2.89.0"
 
 [libraries]
-junit-bom = {module = "org.junit:junit-bom", version.ref = "junit5"}
+junit-bom = {module = "org.junit:junit-bom", version.ref = "junit6"}
 grpc-bom = {module = "io.grpc:grpc-bom", version.ref = "grpc"}
 mockito-bom = {module = "org.mockito:mockito-bom", version.ref = "mockito"}
 errorprone = {module = "com.google.errorprone:error_prone_core", version.ref = "errorprone"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,6 +1,4 @@
 import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.SonatypeHost
-import com.vanniktech.maven.publish.tasks.JavadocJar
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
@@ -83,13 +81,15 @@ version = projectVersion
 mavenPublishing {
     configure(
         KotlinJvm(
-            javadocJar = PublishJavadocJar.Dokka(tasks.dokkaGeneratePublicationHtml.name),
+            javadocJar = PublishJavadocJar.Dokka(tasks.dokkaGeneratePublicationHtml),
             sourcesJar = true,
         ),
     )
 
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = false)
-    signAllPublications()
+    publishToMavenCentral(automaticRelease = false)
+    if (ci.isPresent) {
+        signAllPublications()
+    }
     coordinates(projectGroup, rootProject.name, projectVersion)
 
     pom {
@@ -142,11 +142,6 @@ tasks {
         // Suppress warning: Sharing is only supported for boot loader classes...
         // https://stackoverflow.com/q/54205486/839733
         jvmArgs("-Xshare:off")
-    }
-
-    // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/966
-    withType<JavadocJar> {
-        archiveFileName = "${rootProject.name}-javadoc.jar"
     }
 
     withType<KtLintFormatTask> {

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/ExtensionContextUtils.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/ExtensionContextUtils.kt
@@ -11,7 +11,11 @@ import kotlin.reflect.KFunction1
 private object ExtensionContextUtils {
     internal val NAMESPACE: ExtensionContext.Namespace =
         ExtensionContext.Namespace
-            .create(*GrpcCleanupExtension::class.java.name.split(".").toTypedArray())
+            .create(
+                *GrpcCleanupExtension::class.java.name
+                    .split(".")
+                    .toTypedArray(),
+            )
     internal const val RESOURCES = "resources"
     internal const val RESOURCES_FIELD = "resources-field"
 }
@@ -72,8 +76,8 @@ internal val ExtensionContext.isAccessResourcesField: Boolean
 internal val ExtensionContext.cleanUp: KFunction1<Resources, Unit>
     get() = if (executionException.isPresent) Resources::forceCleanUp else Resources::cleanUp
 
-internal fun ExtensionContext.findResourcesField(): Field? {
-    return generateSequence<Pair<Class<*>?, Field?>>(
+internal fun ExtensionContext.findResourcesField(): Field? =
+    generateSequence<Pair<Class<*>?, Field?>>(
         (requiredTestClass to null),
     ) { (clazz, field) ->
         val fields =
@@ -93,10 +97,8 @@ internal fun ExtensionContext.findResourcesField(): Field? {
             clazz.superclass != null -> (clazz.superclass to field)
             else -> (null to field)
         }
-    }
-        .dropWhile { it.first != null && it.second == null }
+    }.dropWhile { it.first != null && it.second == null }
         .take(1)
         .iterator()
         .next()
         .second
-}

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
@@ -25,7 +25,11 @@ import org.junit.platform.commons.PreconditionViolationException
  * @since 1.0.0
  */
 class GrpcCleanupExtension :
-    BeforeEachCallback, AfterEachCallback, ParameterResolver, BeforeAllCallback, AfterAllCallback {
+    BeforeEachCallback,
+    AfterEachCallback,
+    ParameterResolver,
+    BeforeAllCallback,
+    AfterAllCallback {
     override fun beforeEach(ctx: ExtensionContext) {
         val resources =
             ctx.requiredTestMethod.parameters
@@ -71,9 +75,7 @@ class GrpcCleanupExtension :
     override fun supportsParameter(
         parameterContext: ParameterContext,
         extensionContext: ExtensionContext,
-    ): Boolean {
-        return parameterContext.parameter.type == Resources::class.java
-    }
+    ): Boolean = parameterContext.parameter.type == Resources::class.java
 
     override fun resolveParameter(
         parameterCtx: ParameterContext,

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/Resource.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/Resource.kt
@@ -32,7 +32,9 @@ interface Resource {
     fun awaitRelease(duration: Duration): Boolean
 }
 
-internal sealed class AbstractResource<E : Any>(private val e: E) : Resource {
+internal sealed class AbstractResource<E : Any>(
+    private val e: E,
+) : Resource {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -42,43 +44,39 @@ internal sealed class AbstractResource<E : Any>(private val e: E) : Resource {
         return e == other.e
     }
 
-    override fun hashCode(): Int {
-        return e.hashCode()
-    }
+    override fun hashCode(): Int = e.hashCode()
 
-    override fun toString(): String {
-        return e.toString()
-    }
+    override fun toString(): String = e.toString()
 }
 
-internal class ManagedChannelResource internal constructor(private val channel: ManagedChannel) :
-    AbstractResource<ManagedChannel>(channel) {
-        override fun cleanUp() {
-            channel.shutdown()
-        }
-
-        override fun forceCleanUp() {
-            channel.shutdownNow()
-        }
-
-        override fun awaitRelease(duration: Duration): Boolean {
-            return channel.awaitTermination(duration.toNanos(), TimeUnit.NANOSECONDS)
-        }
+internal class ManagedChannelResource internal constructor(
+    private val channel: ManagedChannel,
+) : AbstractResource<ManagedChannel>(channel) {
+    override fun cleanUp() {
+        channel.shutdown()
     }
 
-internal class ServerResource internal constructor(private val server: Server) :
-    AbstractResource<Server>(
+    override fun forceCleanUp() {
+        channel.shutdownNow()
+    }
+
+    override fun awaitRelease(duration: Duration): Boolean =
+        channel.awaitTermination(duration.toNanos(), TimeUnit.NANOSECONDS)
+}
+
+internal class ServerResource internal constructor(
+    private val server: Server,
+) : AbstractResource<Server>(
         server,
     ) {
-        override fun cleanUp() {
-            server.shutdown()
-        }
-
-        override fun forceCleanUp() {
-            server.shutdownNow()
-        }
-
-        override fun awaitRelease(duration: Duration): Boolean {
-            return server.awaitTermination(duration.toNanos(), TimeUnit.NANOSECONDS)
-        }
+    override fun cleanUp() {
+        server.shutdown()
     }
+
+    override fun forceCleanUp() {
+        server.shutdownNow()
+    }
+
+    override fun awaitRelease(duration: Duration): Boolean =
+        server.awaitTermination(duration.toNanos(), TimeUnit.NANOSECONDS)
+}

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/Resources.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/Resources.kt
@@ -30,9 +30,7 @@ class Resources {
     fun <T : Server> register(
         server: T,
         timeout: Duration = this.timeout,
-    ): Resources {
-        return this.apply { this@Resources.resources[ServerResource(server)] = timeout }
-    }
+    ): Resources = this.apply { this@Resources.resources[ServerResource(server)] = timeout }
 
     /**
      * Registers the given channel with the extension. Once registered, the channel will be automatically
@@ -48,13 +46,12 @@ class Resources {
     fun <T : ManagedChannel> register(
         channel: T,
         timeout: Duration = this.timeout,
-    ): Resources {
-        return this.apply {
+    ): Resources =
+        this.apply {
             this@Resources.resources[
                 ManagedChannelResource(channel),
             ] = timeout
         }
-    }
 
     /**
      * A positive time limit for the registered resources to be released. If the resources fail to
@@ -65,9 +62,7 @@ class Resources {
      *
      * @return this
      */
-    fun timeout(timeout: Duration): Resources {
-        return this.apply { this@Resources.timeout = timeout }
-    }
+    fun timeout(timeout: Duration): Resources = this.apply { this@Resources.timeout = timeout }
 
     internal fun cleanUp() {
         resources.keys.forEach { it.cleanUp() }
@@ -97,13 +92,12 @@ class Resources {
         return successful
     }
 
-    override fun toString(): String {
-        return if (resources.isEmpty()) {
+    override fun toString(): String =
+        if (resources.isEmpty()) {
             "Resources[]"
         } else {
             "Resources${resources.keys.map { it.toString() }}"
         }
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -114,7 +108,5 @@ class Resources {
         return resources.keys == other.resources.keys
     }
 
-    override fun hashCode(): Int {
-        return Objects.hashCode(resources.keys)
-    }
+    override fun hashCode(): Int = Objects.hashCode(resources.keys)
 }

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
@@ -36,7 +36,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectMethod(
                     ExampleTestCase::class.java,
@@ -45,8 +46,7 @@ class GrpcCleanupExtensionIntegrationTests {
                         Resources::class.java,
                     ),
                 ),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -59,7 +59,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val server = mocks.find { it is Server } as Server?
         assertThat(server).isNotNull
         Mockito.verify(server)!!.shutdown()
-        Mockito.verify(server)!!
+        Mockito
+            .verify(server)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -67,7 +68,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val channel = mocks.find { it is ManagedChannel } as ManagedChannel?
         assertThat(channel).isNotNull
         Mockito.verify(channel)!!.shutdown()
-        Mockito.verify(channel)!!
+        Mockito
+            .verify(channel)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -79,7 +81,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectMethod(
                     ExampleTestCase::class.java,
@@ -88,8 +91,7 @@ class GrpcCleanupExtensionIntegrationTests {
                         Resources::class.java,
                     ),
                 ),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -102,7 +104,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val server = mocks.find { it is Server } as Server?
         assertThat(server).isNotNull
         Mockito.verify(server)!!.shutdown()
-        Mockito.verify(server)!!
+        Mockito
+            .verify(server)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -110,7 +113,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val channel = mocks.find { it is ManagedChannel } as ManagedChannel?
         assertThat(channel).isNotNull
         Mockito.verify(channel)!!.shutdown()
-        Mockito.verify(channel)!!
+        Mockito
+            .verify(channel)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -122,7 +126,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectMethod(
                     ExampleTestCase::class.java,
@@ -131,8 +136,7 @@ class GrpcCleanupExtensionIntegrationTests {
                         Resources::class.java,
                     ),
                 ),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -145,7 +149,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val server = mocks.find { it is Server } as Server?
         assertThat(server).isNotNull
         Mockito.verify(server)!!.shutdownNow()
-        Mockito.verify(server)!!
+        Mockito
+            .verify(server)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -153,7 +158,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val channel = mocks.find { it is ManagedChannel } as ManagedChannel?
         assertThat(channel).isNotNull
         Mockito.verify(channel)!!.shutdownNow()
-        Mockito.verify(channel)!!
+        Mockito
+            .verify(channel)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -165,7 +171,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectMethod(
                     ExampleTestCase::class.java,
@@ -174,8 +181,7 @@ class GrpcCleanupExtensionIntegrationTests {
                         Resources::class.java,
                     ),
                 ),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -187,7 +193,8 @@ class GrpcCleanupExtensionIntegrationTests {
         val server = mocks.find { it is Server } as Server?
         assertThat(server).isNotNull
         Mockito.verify(server)!!.shutdown()
-        Mockito.verify(server)!!
+        Mockito
+            .verify(server)!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -196,7 +203,8 @@ class GrpcCleanupExtensionIntegrationTests {
         assertThat(channel).isNotNull
         Mockito.verify(channel)!!.shutdown()
         Mockito.verify(channel)!!.shutdownNow()
-        Mockito.verify(channel, Mockito.never())!!
+        Mockito
+            .verify(channel, Mockito.never())!!
             .awaitTermination(
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(TimeUnit::class.java),
@@ -208,11 +216,11 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase2::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -229,11 +237,11 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase3::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -247,11 +255,11 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testInitializeStaticFieldOnlyOnce() {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase4::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -267,11 +275,11 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase5::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -285,7 +293,8 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testMultipleParametersError(info: TestInfo) {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectMethod(
                     ExampleTestCase::class.java,
@@ -295,8 +304,7 @@ class GrpcCleanupExtensionIntegrationTests {
                         Resources::class.java,
                     ),
                 ),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -307,13 +315,13 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testMultipleInstanceFieldsError() {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(
                     ExampleTestCase6::class.java,
                 ),
-            )
-            .execute()
+            ).execute()
             .allEvents()
             .assertThatEvents()
             .haveExactly(
@@ -327,11 +335,11 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase7::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -345,11 +353,11 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testAlreadyInitializedFieldError() {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase8::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -363,11 +371,11 @@ class GrpcCleanupExtensionIntegrationTests {
         val mocks = mutableListOf<Any>()
         val listener = MockCreationListener { mock, _ -> mocks.add(mock) }
         Mockito.framework().addListener(listener)
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase9::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(
@@ -383,11 +391,11 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testNested() {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(
                 selectClass(ExampleTestCase10::class.java),
-            )
-            .execute()
+            ).execute()
             .testEvents()
             .assertThatEvents()
             .haveExactly(

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ResourcesTest.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ResourcesTest.kt
@@ -51,10 +51,10 @@ class ResourcesTest {
 
     @Test
     fun testCleanUp() {
-        Resources().apply {
-            register(server).register(channel)
-        }
-            .cleanUp()
+        Resources()
+            .apply {
+                register(server).register(channel)
+            }.cleanUp()
 
         verify(server, times(1)).shutdown()
         verify(channel, times(1)).shutdown()
@@ -62,10 +62,10 @@ class ResourcesTest {
 
     @Test
     fun testForceCleanUp() {
-        Resources().apply {
-            register(server).register(channel)
-        }
-            .forceCleanUp()
+        Resources()
+            .apply {
+                register(server).register(channel)
+            }.forceCleanUp()
 
         verify(server, times(1)).shutdownNow()
         verify(channel, times(1)).shutdownNow()

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase.kt
@@ -19,64 +19,64 @@ class ExampleTestCase {
 
     @Test
     fun testSuccessful(resources: Resources) {
-        Mockito.`when`(
-            server.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        )
-            .thenReturn(true)
-        Mockito.`when`(
-            channel.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        )
-            .thenReturn(true)
+        Mockito
+            .`when`(
+                server.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
+        Mockito
+            .`when`(
+                channel.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
         resources.register(server).register(channel)
     }
 
     @Test
     fun testFailedShutdown(resources: Resources) {
-        Mockito.`when`(
-            server.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        )
-            .thenReturn(true)
+        Mockito
+            .`when`(
+                server.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
         resources.register(server).register(channel)
     }
 
     @Test
     fun testException(resources: Resources) {
-        Mockito.`when`(
-            server.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        )
-            .thenReturn(true)
-        Mockito.`when`(
-            channel.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        )
-            .thenReturn(true)
+        Mockito
+            .`when`(
+                server.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
+        Mockito
+            .`when`(
+                channel.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
         resources.register(server).register(channel)
         throw RuntimeException("Boom")
     }
 
     @Test
     fun testTimeout(resources: Resources) {
-        Mockito.`when`(
-            server.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        )
-            .thenAnswer {
+        Mockito
+            .`when`(
+                server.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenAnswer {
                 sleep(1000)
                 true
             }


### PR DESCRIPTION
- libs.versions.toml: Bump dependency versions
- maven-publish: pass TaskProvider to JavadocJar.Dokka, remove archiveFileName workaround, drop removed SonatypeHost API
- publish.yml: replace curl/jq CI-status hack with gh run list check