### PR TITLE
fix(extension): isolate per-test and per-class resources in parallel execution

### DIFF
--- a/lib/src/main/kotlin/com/asarkar/grpc/test/ExtensionContextUtils.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/ExtensionContextUtils.kt
@@ -16,22 +16,43 @@ private object ExtensionContextUtils {
                     .split(".")
                     .toTypedArray(),
             )
+
+    // Per-test (once=false): only ever written to method-level contexts.
+    // Keeping it out of class-level contexts ensures the Store hierarchy walk never returns
+    // a shared list to a concurrent sibling test.
     internal const val RESOURCES = "resources"
+
+    // Per-class (once=true): only ever written to class-level contexts, cleaned in afterAll.
+    internal const val RESOURCES_ONCE = "resources-once"
     internal const val RESOURCES_FIELD = "resources-field"
 }
 
 @Suppress("UNCHECKED_CAST")
-internal var ExtensionContext.resources: MutableMap<Boolean, MutableList<Resources>>
+internal var ExtensionContext.resources: MutableList<Resources>
     get() =
         getStore(ExtensionContextUtils.NAMESPACE)
             .getOrDefault(
                 ExtensionContextUtils.RESOURCES,
-                MutableMap::class.java,
-                mutableMapOf<Boolean, MutableList<Resources>>(),
-            ) as MutableMap<Boolean, MutableList<Resources>>
+                MutableList::class.java,
+                mutableListOf<Resources>(),
+            ) as MutableList<Resources>
     set(value) {
         getStore(ExtensionContextUtils.NAMESPACE)
             .put(ExtensionContextUtils.RESOURCES, value)
+    }
+
+@Suppress("UNCHECKED_CAST")
+internal var ExtensionContext.resourcesOnce: MutableList<Resources>
+    get() =
+        getStore(ExtensionContextUtils.NAMESPACE)
+            .getOrDefault(
+                ExtensionContextUtils.RESOURCES_ONCE,
+                MutableList::class.java,
+                mutableListOf<Resources>(),
+            ) as MutableList<Resources>
+    set(value) {
+        getStore(ExtensionContextUtils.NAMESPACE)
+            .put(ExtensionContextUtils.RESOURCES_ONCE, value)
     }
 
 internal var ExtensionContext.resourcesField: Field?

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
@@ -52,7 +52,7 @@ class GrpcCleanupExtension :
 
     override fun afterEach(ctx: ExtensionContext) {
         var successful = true
-        ctx.resources[false]?.forEach {
+        ctx.resources.forEach {
             ctx.cleanUp(it)
             successful = it.awaitRelease()
         }
@@ -89,10 +89,11 @@ class GrpcCleanupExtension :
                 )
 
         return Resources().also { resources ->
-            extensionCtx.resources =
-                extensionCtx.resources.also {
-                    it.getOrPut(once) { mutableListOf() }.add(resources)
-                }
+            if (once) {
+                extensionCtx.resourcesOnce = extensionCtx.resourcesOnce.also { it.add(resources) }
+            } else {
+                extensionCtx.resources = extensionCtx.resources.also { it.add(resources) }
+            }
         }
     }
 
@@ -118,7 +119,7 @@ class GrpcCleanupExtension :
             ctx.cleanUp(it)
             successful = it.awaitRelease()
         }
-        ctx.resources[true]?.forEach {
+        ctx.resourcesOnce.forEach {
             ctx.cleanUp(it)
             successful = it.awaitRelease()
         }

--- a/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
+++ b/lib/src/main/kotlin/com/asarkar/grpc/test/GrpcCleanupExtension.kt
@@ -54,13 +54,13 @@ class GrpcCleanupExtension :
         var successful = true
         ctx.resources.forEach {
             ctx.cleanUp(it)
-            successful = it.awaitRelease()
+            successful = it.awaitRelease() && successful
         }
 
         if (ctx.isAccessResourcesField) {
             ctx.resourcesInstance?.also {
                 ctx.cleanUp(it)
-                successful = it.awaitRelease()
+                successful = it.awaitRelease() && successful
 
                 ctx.resourcesInstance = null
             }
@@ -117,11 +117,11 @@ class GrpcCleanupExtension :
         var successful = true
         ctx.resourcesInstance?.also {
             ctx.cleanUp(it)
-            successful = it.awaitRelease()
+            successful = it.awaitRelease() && successful
         }
         ctx.resourcesOnce.forEach {
             ctx.cleanUp(it)
-            successful = it.awaitRelease()
+            successful = it.awaitRelease() && successful
         }
         if (!successful) {
             throw PostconditionViolationException(

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
@@ -397,15 +397,15 @@ class GrpcCleanupExtensionIntegrationTests {
         // Enables parallel execution only for this EngineTestKit run, not globally.
         // With the bug, testA fails because testB's afterEach prematurely shuts down
         // testA's channel via the shared MutableMap in the class-level Store entry.
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
             .configurationParameter("junit.jupiter.execution.parallel.mode.default", "concurrent")
             .configurationParameter("junit.jupiter.execution.parallel.config.strategy", "fixed")
             .configurationParameter(
                 "junit.jupiter.execution.parallel.config.fixed.parallelism",
                 "2",
-            )
-            .selectors(selectClass(ExampleTestCase11::class.java))
+            ).selectors(selectClass(ExampleTestCase11::class.java))
             .execute()
             .testEvents()
             .assertThatEvents()
@@ -417,7 +417,8 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testMaskedFailureInAfterEach() {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(selectClass(ExampleTestCase12::class.java))
             .execute()
             .testEvents()
@@ -430,7 +431,8 @@ class GrpcCleanupExtensionIntegrationTests {
 
     @Test
     fun testMaskedFailureInAfterAll() {
-        EngineTestKit.engine(JUNIT_JUPITER)
+        EngineTestKit
+            .engine(JUNIT_JUPITER)
             .selectors(selectClass(ExampleTestCase13::class.java))
             .execute()
             .allEvents()

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
@@ -2,6 +2,7 @@ package com.asarkar.grpc.test
 
 import com.asarkar.grpc.test.ignore.ExampleTestCase
 import com.asarkar.grpc.test.ignore.ExampleTestCase10
+import com.asarkar.grpc.test.ignore.ExampleTestCase11
 import com.asarkar.grpc.test.ignore.ExampleTestCase2
 import com.asarkar.grpc.test.ignore.ExampleTestCase3
 import com.asarkar.grpc.test.ignore.ExampleTestCase4
@@ -387,6 +388,29 @@ class GrpcCleanupExtensionIntegrationTests {
 
         assertThat(mocks).allMatch { it is Set<*> }
         assertThat(mocks.flatMap { it as Set<*> }.toSet()).hasSize(3)
+    }
+
+    @Test
+    fun testConcurrentResourceIsolation() {
+        // Enables parallel execution only for this EngineTestKit run, not globally.
+        // With the bug, testA fails because testB's afterEach prematurely shuts down
+        // testA's channel via the shared MutableMap in the class-level Store entry.
+        EngineTestKit.engine(JUNIT_JUPITER)
+            .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+            .configurationParameter("junit.jupiter.execution.parallel.mode.default", "concurrent")
+            .configurationParameter("junit.jupiter.execution.parallel.config.strategy", "fixed")
+            .configurationParameter(
+                "junit.jupiter.execution.parallel.config.fixed.parallelism",
+                "2",
+            )
+            .selectors(selectClass(ExampleTestCase11::class.java))
+            .execute()
+            .testEvents()
+            .assertThatEvents()
+            .haveExactly(
+                2,
+                event(finishedSuccessfully()),
+            )
     }
 
     @Test

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/GrpcCleanupExtensionIntegrationTests.kt
@@ -3,6 +3,8 @@ package com.asarkar.grpc.test
 import com.asarkar.grpc.test.ignore.ExampleTestCase
 import com.asarkar.grpc.test.ignore.ExampleTestCase10
 import com.asarkar.grpc.test.ignore.ExampleTestCase11
+import com.asarkar.grpc.test.ignore.ExampleTestCase12
+import com.asarkar.grpc.test.ignore.ExampleTestCase13
 import com.asarkar.grpc.test.ignore.ExampleTestCase2
 import com.asarkar.grpc.test.ignore.ExampleTestCase3
 import com.asarkar.grpc.test.ignore.ExampleTestCase4
@@ -410,6 +412,32 @@ class GrpcCleanupExtensionIntegrationTests {
             .haveExactly(
                 2,
                 event(finishedSuccessfully()),
+            )
+    }
+
+    @Test
+    fun testMaskedFailureInAfterEach() {
+        EngineTestKit.engine(JUNIT_JUPITER)
+            .selectors(selectClass(ExampleTestCase12::class.java))
+            .execute()
+            .testEvents()
+            .assertThatEvents()
+            .haveExactly(
+                1,
+                event(finishedWithFailure(instanceOf(PostconditionViolationException::class.java))),
+            )
+    }
+
+    @Test
+    fun testMaskedFailureInAfterAll() {
+        EngineTestKit.engine(JUNIT_JUPITER)
+            .selectors(selectClass(ExampleTestCase13::class.java))
+            .execute()
+            .allEvents()
+            .assertThatEvents()
+            .haveExactly(
+                1,
+                event(finishedWithFailure(instanceOf(PostconditionViolationException::class.java))),
             )
     }
 

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase11.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase11.kt
@@ -1,0 +1,70 @@
+package com.asarkar.grpc.test.ignore
+
+import com.asarkar.grpc.test.GrpcCleanupExtension
+import com.asarkar.grpc.test.Resources
+import com.asarkar.grpc.test.TestUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduces the parallel-execution resource-isolation bug.
+ *
+ * The bug: [GrpcCleanupExtension]'s [ExtensionContext.Store] uses [getOrDefault], which walks
+ * the context hierarchy. When [beforeAll] stores its [Resources] under the class-level context,
+ * concurrent [resolveParameter] calls for [testA] and [testB] both find that same mutable map
+ * via the hierarchy walk and append their own resources to the shared `false`-keyed list.
+ *
+ * Consequence: [afterEach] for [testB] cleans the shared list — which now contains [testA]'s
+ * channel — while [testA] is still running. [testA] then observes `channelA.isShutdown == true`
+ * and fails.
+ *
+ * Run via [com.asarkar.grpc.test.GrpcCleanupExtensionIntegrationTests.testConcurrentResourceIsolation]
+ * with parallel execution enabled; never run directly by the Gradle test task (excluded via the
+ * `ignore` package filter in build.gradle.kts).
+ */
+@ExtendWith(GrpcCleanupExtension::class)
+@TestInstance(PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
+class ExampleTestCase11 {
+    companion object {
+        @JvmStatic
+        val barrier = CyclicBarrier(2)
+    }
+
+    @BeforeAll
+    fun beforeAll(resources: Resources) {
+        // Storing any resource here causes the class-level ExtensionContext.Store to hold the
+        // shared MutableMap<Boolean, MutableList<Resources>> under the "resources" key.
+        // Concurrent method-level resolveParameter calls then retrieve that same map object
+        // via getOrDefault's hierarchy walk, creating the shared-state race.
+        resources.register(TestUtils.randomChannel())
+    }
+
+    @Test
+    fun testA(resources: Resources) {
+        val ch = TestUtils.randomChannel()
+        resources.register(ch)
+        // Both tests must have registered before either exits, ensuring both are in the
+        // shared resource list before testB's afterEach fires.
+        barrier.await(5, TimeUnit.SECONDS)
+        // Give testB time to return and its afterEach to run. With the bug, afterEach for
+        // testB drains the shared list which includes testA's channel, shutting it down.
+        Thread.sleep(300)
+        assertThat(ch.isShutdown).isFalse()
+    }
+
+    @Test
+    fun testB(resources: Resources) {
+        resources.register(TestUtils.randomChannel())
+        barrier.await(5, TimeUnit.SECONDS)
+        // Return immediately so afterEach fires while testA is still sleeping.
+    }
+}

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase11.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase11.kt
@@ -9,8 +9,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.TimeUnit
 
@@ -37,6 +39,9 @@ class ExampleTestCase11 {
     companion object {
         @JvmStatic
         val barrier = CyclicBarrier(2)
+
+        @JvmStatic
+        val testBDone = CountDownLatch(1)
     }
 
     @BeforeAll
@@ -55,9 +60,11 @@ class ExampleTestCase11 {
         // Both tests must have registered before either exits, ensuring both are in the
         // shared resource list before testB's afterEach fires.
         barrier.await(5, TimeUnit.SECONDS)
-        // Give testB time to return and its afterEach to run. With the bug, afterEach for
-        // testB drains the shared list which includes testA's channel, shutting it down.
-        Thread.sleep(300)
+        // Wait until testB's body has returned, then give its afterEach a brief window to
+        // dispatch. With the bug, that afterEach drains the shared list — which includes
+        // testA's channel — shutting it down before this assertion runs.
+        testBDone.await(5, TimeUnit.SECONDS)
+        Thread.sleep(50)
         assertThat(ch.isShutdown).isFalse()
     }
 
@@ -65,6 +72,7 @@ class ExampleTestCase11 {
     fun testB(resources: Resources) {
         resources.register(TestUtils.randomChannel())
         barrier.await(5, TimeUnit.SECONDS)
-        // Return immediately so afterEach fires while testA is still sleeping.
+        // Signal that testB is about to return so testA only waits on afterEach dispatch.
+        testBDone.countDown()
     }
 }

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase12.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase12.kt
@@ -28,21 +28,23 @@ class ExampleTestCase12 {
     @Test
     fun testMaskedFailure(params: Resources) {
         val server = Mockito.mock(Server::class.java)
-        Mockito.`when`(
-            server.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        ).thenReturn(false)
+        Mockito
+            .`when`(
+                server.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(false)
         params.register(server)
 
         val channel = Mockito.mock(ManagedChannel::class.java)
-        Mockito.`when`(
-            channel.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        ).thenReturn(true)
+        Mockito
+            .`when`(
+                channel.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
         resources.register(channel)
     }
 }

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase12.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase12.kt
@@ -1,0 +1,48 @@
+package com.asarkar.grpc.test.ignore
+
+import com.asarkar.grpc.test.GrpcCleanupExtension
+import com.asarkar.grpc.test.Resources
+import io.grpc.ManagedChannel
+import io.grpc.Server
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduces the success-aggregation masking bug in [GrpcCleanupExtension.afterEach].
+ *
+ * afterEach releases the method parameter [Resources] first, then the instance-field
+ * [Resources]. Each release overwrites `successful` instead of accumulating it, so a field
+ * release that succeeds masks a parameter release that failed. The parameter resource here
+ * fails to release while the field resource succeeds; afterEach must still fail the test.
+ *
+ * Run via [com.asarkar.grpc.test.GrpcCleanupExtensionIntegrationTests.testMaskedFailureInAfterEach];
+ * excluded from the Gradle test task via the `ignore` package filter.
+ */
+@ExtendWith(GrpcCleanupExtension::class)
+class ExampleTestCase12 {
+    private lateinit var resources: Resources
+
+    @Test
+    fun testMaskedFailure(params: Resources) {
+        val server = Mockito.mock(Server::class.java)
+        Mockito.`when`(
+            server.awaitTermination(
+                ArgumentMatchers.anyLong(),
+                ArgumentMatchers.any(TimeUnit::class.java),
+            ),
+        ).thenReturn(false)
+        params.register(server)
+
+        val channel = Mockito.mock(ManagedChannel::class.java)
+        Mockito.`when`(
+            channel.awaitTermination(
+                ArgumentMatchers.anyLong(),
+                ArgumentMatchers.any(TimeUnit::class.java),
+            ),
+        ).thenReturn(true)
+        resources.register(channel)
+    }
+}

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase13.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase13.kt
@@ -1,0 +1,56 @@
+package com.asarkar.grpc.test.ignore
+
+import com.asarkar.grpc.test.GrpcCleanupExtension
+import com.asarkar.grpc.test.Resources
+import io.grpc.ManagedChannel
+import io.grpc.Server
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduces the success-aggregation masking bug in [GrpcCleanupExtension.afterAll].
+ *
+ * afterAll releases the instance-field [Resources] first, then the per-class (`once`) [Resources].
+ * Each release overwrites `successful` instead of accumulating it, so an `once` release that
+ * succeeds masks a field release that failed. The field resource here fails to release while the
+ * `once` resource succeeds; afterAll must still fail the container.
+ *
+ * Run via [com.asarkar.grpc.test.GrpcCleanupExtensionIntegrationTests.testMaskedFailureInAfterAll];
+ * excluded from the Gradle test task via the `ignore` package filter.
+ */
+@ExtendWith(GrpcCleanupExtension::class)
+@TestInstance(PER_CLASS)
+class ExampleTestCase13 {
+    private lateinit var resources: Resources
+
+    @BeforeAll
+    fun beforeAll(once: Resources) {
+        val channel = Mockito.mock(ManagedChannel::class.java)
+        Mockito.`when`(
+            channel.awaitTermination(
+                ArgumentMatchers.anyLong(),
+                ArgumentMatchers.any(TimeUnit::class.java),
+            ),
+        ).thenReturn(true)
+        once.register(channel)
+
+        val server = Mockito.mock(Server::class.java)
+        Mockito.`when`(
+            server.awaitTermination(
+                ArgumentMatchers.anyLong(),
+                ArgumentMatchers.any(TimeUnit::class.java),
+            ),
+        ).thenReturn(false)
+        resources.register(server)
+    }
+
+    @Test
+    fun test1() {
+    }
+}

--- a/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase13.kt
+++ b/lib/src/test/kotlin/com/asarkar/grpc/test/ignore/ExampleTestCase13.kt
@@ -32,21 +32,23 @@ class ExampleTestCase13 {
     @BeforeAll
     fun beforeAll(once: Resources) {
         val channel = Mockito.mock(ManagedChannel::class.java)
-        Mockito.`when`(
-            channel.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        ).thenReturn(true)
+        Mockito
+            .`when`(
+                channel.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(true)
         once.register(channel)
 
         val server = Mockito.mock(Server::class.java)
-        Mockito.`when`(
-            server.awaitTermination(
-                ArgumentMatchers.anyLong(),
-                ArgumentMatchers.any(TimeUnit::class.java),
-            ),
-        ).thenReturn(false)
+        Mockito
+            .`when`(
+                server.awaitTermination(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(TimeUnit::class.java),
+                ),
+            ).thenReturn(false)
         resources.register(server)
     }
 


### PR DESCRIPTION
Fixes #17

## Problem

`GrpcCleanupExtension` stored per-test and per-class `Resources` under one
`ExtensionContext.Store` key. `Store.getOrDefault` walks the context hierarchy, so a
`@BeforeAll`-resolved entry in the class-level context was visible to every method-level
context. Under parallel execution, concurrent `@Test` `resolveParameter` calls appended to
that one shared list; the first test's `afterEach` then drained it and shut down a still-running
sibling's gRPC channel — `UNAVAILABLE: Channel shutdown invoked` mid-flight.

## Fix

Two changes:

1. **Separate Store keys per lifetime.** `"resources"` (per-test) is written only to
   method-level contexts; `"resources-once"` (per-class) only to class-level contexts and
   cleaned in `afterAll`. A sibling's hierarchy walk no longer finds a shared list.

2. **Cumulative cleanup-success aggregation.** `afterEach`/`afterAll` assigned each release
   result with `=`, so a later success masked an earlier failure and a leaked resource passed
   silently. Now accumulated with `&&`. Evaluated as `it.awaitRelease() && successful` rather
   than `successful && it.awaitRelease()`: `awaitRelease()` force-cleans on failure, so the
   reverse order would short-circuit and skip releasing every remaining resource once one failed.

## Tests

- `ExampleTestCase11` + `testConcurrentResourceIsolation` reproduce the race deterministically
  with a `CyclicBarrier` and a fixed parallelism-2 `EngineTestKit` pool.
- `ExampleTestCase12`/`ExampleTestCase13` + `testMaskedFailureInAfterEach`/`testMaskedFailureInAfterAll`
  cover the masking bug for both lifecycle paths — failing before change 2, passing after.
